### PR TITLE
Fix curl building instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ mkdir curl/cmakebuild
 cd curl/cmakebuild
 cmake ../ -DCMAKE_C_COMPILER=/full/path/to/widcc -DCMAKE_C_FLAGS=-fPIC
 make -j
-make quiet-test -j
+make test-quiet -j
 ```
 `gcc 4.7.4`
 ```


### PR DESCRIPTION
Curl does not have `quiet-test` make rule, instead, it's named `test-quiet``.